### PR TITLE
Loop through all attachments, no breaking

### DIFF
--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -79,13 +79,10 @@ RCT_REMAP_METHOD(data,
         [attachments enumerateObjectsUsingBlock:^(NSItemProvider *provider, NSUInteger idx, BOOL *stop) {
             if([provider hasItemConformingToTypeIdentifier:URL_IDENTIFIER]) {
                 urlProvider = provider;
-                *stop = YES;
             } else if ([provider hasItemConformingToTypeIdentifier:TEXT_IDENTIFIER]){
                 textProvider = provider;
-                *stop = YES;
             } else if ([provider hasItemConformingToTypeIdentifier:IMAGE_IDENTIFIER]){
                 imageProvider = provider;
-                *stop = YES;
             }
         }];
 


### PR DESCRIPTION
  * If there is a URL or an image, we want to find it even if we've already found some plain text
  * Specifically, Firefox and Brave put the title earlier in the list than the URL, so the URL is never found if we break out of the iteration

The share extension works roughly like this:

1. Retrieve a list of items from the share context
2. Loop through the items and look for keys that we think we can handle (URL, plain text, image)
3. If a URL was found, pass it to the JS layer
  - *otherwise* if an image was found, pass it
  - *otherwise* if plain text was found, pass it

The bug here is that we would break out of the loop in `2` as soon as we found anything, and since Firefox and Brave place the title as the first item in the list, we would never get to the URL. (Safari *only* passes the URL.)

So the fix is simple: don't break out of the loop 😄 

----

Some additional thoughts:

* Only at most *one* of the attached objects is ever passed to the JS caller, which is fine for us here (since the URL takes precedence) but a more general solution would be to pass on everything that's found to JS
* iOS makes the title available some other way (I think) which is why we get it at all - it was never through the extension
* It's also possible to inspect the whole web page with custom JS as part of launching the share extension - not clear to me if we're already doing that but in a less standard way - the extension OOMs sometimes during debugging (extensions are allowed a small mem budget) which could have something to do with this, but I'm just guessing
* All the other things I thought I had found out about the difference between Safari and Ffx/Brave by looking at their respective code bases turned out to be red herrings.
